### PR TITLE
chore(deps): bump fast-uri from 3.1.4 to 3.1.5 in /frontend (#453)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9739,9 +9739,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -126,7 +126,7 @@
     "prismjs": "^1.30.0",
     "uuid": "^14.0.0",
     "postcss": "^8.5.10",
-    "fast-uri": "^3.1.4",
+    "fast-uri": "^3.1.5",
     "brace-expansion": "^5.0.6",
     "ws": "^8.21.0",
     "undici": "^7.16.0",


### PR DESCRIPTION
chore(deps): bump fast-uri from 3.1.4 to 3.1.5 in /frontend (#453)
